### PR TITLE
allow custom tool retrieval functions that don't use Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ tool_registry = {
 def retrieve_tools(
     category: Literal["billing", "service"],
 ) -> list[str]:
+    """Get tools for a category."""
     if category == "billing":
         return ["id_1", "id_2"]
     else:

--- a/README.md
+++ b/README.md
@@ -171,3 +171,26 @@ builder = create_agent(
 )
 agent = builder.compile(store=store)
 ```
+
+#### Retrieving tools without LangGraph Store
+You can implement arbitrary logic for the tool retrieval, which does not have to run
+semantic search against a query. Below, we return collections of tools corresponding
+to categories:
+```python
+tool_registry = {
+    "id_1": get_balance,
+    "id_2": get_history,
+    "id_3": create_ticket,
+}
+
+def retrieve_tools(
+    category: Literal["billing", "service"],
+) -> list[str]:
+    if category == "billing":
+        return ["id_1", "id_2"]
+    else:
+        return ["id_3"]
+```
+> [!TIP]
+> Because the argument schema is inferred from type hints, type hinting the function
+argument as a `Literal` will signal that the LLM should populate a categorical value.

--- a/langgraph_bigtool/graph.py
+++ b/langgraph_bigtool/graph.py
@@ -83,7 +83,8 @@ def create_agent(
 
     def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         selected_tools = [tool_registry[id] for id in state["selected_tool_ids"]]
-        llm_with_tools = llm.bind_tools([retrieve_tools_function, *selected_tools])
+        to_bind = retrieve_tools_function or retrieve_tools_coroutine
+        llm_with_tools = llm.bind_tools([to_bind, *selected_tools])
         response = llm_with_tools.invoke(state["messages"])
         return {"messages": [response]}
 
@@ -91,7 +92,8 @@ def create_agent(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
         selected_tools = [tool_registry[id] for id in state["selected_tool_ids"]]
-        llm_with_tools = llm.bind_tools([retrieve_tools_coroutine, *selected_tools])
+        to_bind = retrieve_tools_coroutine or retrieve_tools_function
+        llm_with_tools = llm.bind_tools([to_bind, *selected_tools])
         response = await llm_with_tools.ainvoke(state["messages"])
         return {"messages": [response]}
 

--- a/tests/unit_tests/test_end_to_end.py
+++ b/tests/unit_tests/test_end_to_end.py
@@ -200,7 +200,7 @@ async def run_end_to_end_test_async(
     _validate_result(result)
 
 
-def custom_retrieve_tools(
+def custom_retrieve_tools_store(
     query: str,
     *,
     store: Annotated[BaseStore, InjectedStore],
@@ -208,7 +208,7 @@ def custom_retrieve_tools(
     raise AssertionError
 
 
-async def acustom_retrieve_tools(
+async def acustom_retrieve_tools_store(
     query: str,
     *,
     store: Annotated[BaseStore, InjectedStore],
@@ -216,7 +216,22 @@ async def acustom_retrieve_tools(
     raise AssertionError
 
 
-def test_end_to_end() -> None:
+def custom_retrieve_tools_no_store(query: str) -> list[str]:
+    raise AssertionError
+
+
+async def acustom_retrieve_tools_no_store(query: str) -> list[str]:
+    raise AssertionError
+
+
+@pytest.mark.parametrize(
+    "custom_retrieve_tools, acustom_retrieve_tools",
+    [
+        (custom_retrieve_tools_store, acustom_retrieve_tools_store),
+        (custom_retrieve_tools_no_store, acustom_retrieve_tools_no_store),
+    ],
+)
+def test_end_to_end(custom_retrieve_tools, acustom_retrieve_tools) -> None:
     # Default
     fake_llm, fake_embeddings = _get_fake_llm_and_embeddings()
     run_end_to_end_test(fake_llm, fake_embeddings)
@@ -251,7 +266,14 @@ def test_end_to_end() -> None:
         )
 
 
-async def test_end_to_end_async() -> None:
+@pytest.mark.parametrize(
+    "custom_retrieve_tools, acustom_retrieve_tools",
+    [
+        (custom_retrieve_tools_store, acustom_retrieve_tools_store),
+        (custom_retrieve_tools_no_store, acustom_retrieve_tools_no_store),
+    ],
+)
+async def test_end_to_end_async(custom_retrieve_tools, acustom_retrieve_tools) -> None:
     # Default
     fake_llm, fake_embeddings = _get_fake_llm_and_embeddings()
     await run_end_to_end_test_async(fake_llm, fake_embeddings)


### PR DESCRIPTION
```python
from typing import Literal

from langchain.chat_models import init_chat_model
from langchain_core.tools import tool
from langgraph_bigtool import create_agent

@tool
def number_bedrooms(house_id: str) -> int:
    """Get number of bedrooms."""
    return 2

@tool
def number_bathrooms(house_id: str) -> int:
    """Get number of bathrooms."""
    return 2

@tool
def describe_cat(cat_id: str) -> str:
    """Get a description of a cat."""
    return "It's a cute fluffy cat."


tool_registry = {
    "id_1": number_bedrooms,
    "id_2": number_bathrooms,
    "id_3": describe_cat,
}

def retrieve_tools(
    category: Literal["house", "pet"],
) -> list[str]:
    if category == "house":
        return ["id_1", "id_2"]
    else:
        return ["id_3"]

llm = init_chat_model("openai:gpt-4o")
builder = create_agent(
    llm,
    tool_registry,
    retrieve_tools_function=retrieve_tools,
)
agent = builder.compile()
```
```python

input_message = "How many bedrooms does house abc123 have?"

async for step in agent.astream(
    {"messages": input_message},
    stream_mode="updates",
):
    for _, update in step.items():
        for message in update.get("messages", []):
            message.pretty_print()
```
Currently this will raise
> TypeError: retrieve_tools() got an unexpected keyword argument 'store'